### PR TITLE
Don't allow empty fields

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -452,10 +452,8 @@ export default {
           return;
         }
 
-        // eslint-disable-next-line no-param-reassign
-        field.innerHTML = field.innerHTML.trim() || '-';
-
-        this.getCardFromId(cardId)[property] = field.innerHTML;
+        this.getCardFromId(cardId)[property] = field.innerHTML.trim() || '-';
+        this.$forceUpdate();
       };
 
       const outOfFocusBehaviour = () => {

--- a/src/app.vue
+++ b/src/app.vue
@@ -452,7 +452,10 @@ export default {
           return;
         }
 
-        this.getCardFromId(cardId)[property] = field.innerHTML.trim();
+        // eslint-disable-next-line no-param-reassign
+        field.innerHTML = field.innerHTML.trim() || '-';
+
+        this.getCardFromId(cardId)[property] = field.innerHTML;
       };
 
       const outOfFocusBehaviour = () => {


### PR DESCRIPTION
I've tried to change only the property value:
`this.getCardFromId(cardId)[property] = field.innerHTML.trim() || '-';`

But the field shows as empty until reload the page.